### PR TITLE
LandmarkDetail,CircleImage,MapViewが変数を受け取れるように変更

### DIFF
--- a/Landmark.xcodeproj/project.pbxproj
+++ b/Landmark.xcodeproj/project.pbxproj
@@ -8,7 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		BA3CCB082647B6ED006AEE80 /* LandmarkApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA3CCB072647B6ED006AEE80 /* LandmarkApp.swift */; };
-		BA3CCB0A2647B6ED006AEE80 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA3CCB092647B6ED006AEE80 /* ContentView.swift */; };
+		BA3CCB0A2647B6ED006AEE80 /* LandmarkDetail.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA3CCB092647B6ED006AEE80 /* LandmarkDetail.swift */; };
 		BA3CCB0C2647B6EE006AEE80 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = BA3CCB0B2647B6EE006AEE80 /* Assets.xcassets */; };
 		BA3CCB0F2647B6EE006AEE80 /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = BA3CCB0E2647B6EE006AEE80 /* Preview Assets.xcassets */; };
 		BA3CCB172647B79A006AEE80 /* CircleImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA3CCB162647B79A006AEE80 /* CircleImage.swift */; };
@@ -23,14 +23,14 @@
 /* Begin PBXFileReference section */
 		BA3CCB042647B6ED006AEE80 /* Landmark.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Landmark.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		BA3CCB072647B6ED006AEE80 /* LandmarkApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LandmarkApp.swift; sourceTree = "<group>"; };
-		BA3CCB092647B6ED006AEE80 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
+		BA3CCB092647B6ED006AEE80 /* LandmarkDetail.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LandmarkDetail.swift; sourceTree = "<group>"; };
 		BA3CCB0B2647B6EE006AEE80 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		BA3CCB0E2647B6EE006AEE80 /* Preview Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Preview Assets.xcassets"; sourceTree = "<group>"; };
 		BA3CCB102647B6EE006AEE80 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		BA3CCB162647B79A006AEE80 /* CircleImage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CircleImage.swift; sourceTree = "<group>"; };
 		BA3CCB182647B960006AEE80 /* MapView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MapView.swift; sourceTree = "<group>"; };
 		BA67AE34264FF17400166DDE /* landmarkData.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = landmarkData.json; sourceTree = "<group>"; };
-		BA67AE36264FF1DF00166DDE /* Landmark.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Landmark.swift; sourceTree = "<group>"; };
+		BA67AE36264FF1DF00166DDE /* Landmark.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Landmark.swift; sourceTree = "<group>"; };
 		BA67AE38264FF3FB00166DDE /* ModelData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModelData.swift; sourceTree = "<group>"; };
 		BA67AE43264FFFDF00166DDE /* LandmarkRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LandmarkRow.swift; sourceTree = "<group>"; };
 		BA67AE45265000E700166DDE /* LandmarkList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LandmarkList.swift; sourceTree = "<group>"; };
@@ -98,7 +98,7 @@
 			children = (
 				BA67AE43264FFFDF00166DDE /* LandmarkRow.swift */,
 				BA67AE45265000E700166DDE /* LandmarkList.swift */,
-				BA3CCB092647B6ED006AEE80 /* ContentView.swift */,
+				BA3CCB092647B6ED006AEE80 /* LandmarkDetail.swift */,
 				BA3CCB162647B79A006AEE80 /* CircleImage.swift */,
 				BA3CCB182647B960006AEE80 /* MapView.swift */,
 			);
@@ -184,7 +184,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				BA3CCB0A2647B6ED006AEE80 /* ContentView.swift in Sources */,
+				BA3CCB0A2647B6ED006AEE80 /* LandmarkDetail.swift in Sources */,
 				BA3CCB192647B960006AEE80 /* MapView.swift in Sources */,
 				BA3CCB082647B6ED006AEE80 /* LandmarkApp.swift in Sources */,
 				BA67AE46265000E700166DDE /* LandmarkList.swift in Sources */,

--- a/Landmark/LandmarkApp.swift
+++ b/Landmark/LandmarkApp.swift
@@ -11,7 +11,7 @@ import SwiftUI
 struct LandmarkApp: App {
     var body: some Scene {
         WindowGroup {
-            ContentView()
+            LandmarkList()
                 .onAppear {
                     let l = load()
                     print(l)

--- a/Landmark/Model/Landmark.swift
+++ b/Landmark/Model/Landmark.swift
@@ -10,8 +10,18 @@ import Foundation
 struct Landmark: Decodable {
     let id: Int
     let name: String
-    let park: String
+    let category: String
+    let city: String
     let state: String
+    let isFeatured: Bool
+    let isFavorite: Bool
+    let park: String
+    let coordinates: Coordinate
     let description: String
-    
+    let imageName: String
+}
+
+struct Coordinate: Decodable {
+    let longitude: Double
+    let latitude: Double
 }

--- a/Landmark/Views/CircleImage.swift
+++ b/Landmark/Views/CircleImage.swift
@@ -8,8 +8,9 @@
 import SwiftUI
 
 struct CircleImage: View {
+    let imageName: String
     var body: some View {
-        Image("100nen")
+        Image(imageName)
             .clipShape(Circle())
             .overlay(Circle().stroke(Color.white, lineWidth: 4))
             .shadow(radius: 7)
@@ -18,6 +19,6 @@ struct CircleImage: View {
 
 struct CircleImage_Previews: PreviewProvider {
     static var previews: some View {
-        CircleImage()
+        CircleImage(imageName: "100nen")
     }
 }

--- a/Landmark/Views/LandmarkDetail.swift
+++ b/Landmark/Views/LandmarkDetail.swift
@@ -7,19 +7,21 @@
 
 import SwiftUI
 
-struct ContentView: View {
+struct LandmarkDetail: View {
+    var landmark: Landmark
+    
     var body: some View {
         VStack {
-            MapView()
+            MapView(coordinates: landmark.coordinates)
                 .ignoresSafeArea(edges:. top)
                 .frame(height: 300)
             
-            CircleImage()
+            CircleImage(imageName: landmark.imageName)
                 .offset(y: -130)
                 .padding(.bottom, -130)
             
             VStack(alignment: .leading) {
-                Text("百年記念館")
+                Text(landmark.name)
                     .font(.title)
                 HStack {
                     Text("東京工業大学")
@@ -44,11 +46,25 @@ struct ContentView: View {
     }
 }
 
-struct ContentView_Previews: PreviewProvider {
+struct LandmarkDetail_Previews: PreviewProvider {
     static var previews: some View {
-        ContentView()
-            
-            
-            
+        LandmarkDetail(
+            landmark: Landmark(
+                id: 1001,
+                name: "Turtle Rock",
+                category: "Rivers",
+                city: "Twentynine Palms",
+                state: "California",
+                isFeatured: true,
+                isFavorite: true,
+                park: "Joshua Tree National Park",
+                coordinates: Coordinate(
+                    longitude: -116.166868,
+                    latitude: 34.011286
+                ),
+                description: "Suscipit inceptos ...",
+                imageName: "turtlerock"
+            )
+        )            
     }
 }

--- a/Landmark/Views/LandmarkList.swift
+++ b/Landmark/Views/LandmarkList.swift
@@ -7,20 +7,55 @@
 
 import SwiftUI
 
+
 struct LandmarkList: View {
+    let landmark1 = Landmark(
+        id: 1001,
+        name: "Turtle Rock",
+        category: "Rivers",
+        city: "Twentynine Palms",
+        state: "California",
+        isFeatured: true,
+        isFavorite: true,
+        park: "Joshua Tree National Park",
+        coordinates: Coordinate(
+            longitude: -116.166868,
+            latitude: 34.011286
+        ),
+        description: "Suscipit inceptos ...",
+        imageName: "turtlerock"
+    )
+
+    let landmark2 = Landmark(
+        id: 1002,
+        name: "Silver Salmon Creek",
+        category: "Lakes",
+        city: "Port Alsworth",
+        state: "Alaska",
+        isFeatured: false,
+        isFavorite: false,
+        park: "Lake Clark National Park and Preserve",
+        coordinates: Coordinate(
+            longitude: -152.665167,
+            latitude: 59.980167
+        ),
+        description: "Suscipit inceptos ...",
+        imageName: "silversalmoncreek"
+    )
+
     var body: some View {
         NavigationView{
             List {
                 NavigationLink(
-                    destination: ContentView(),
+                    destination: LandmarkDetail(landmark: landmark1),
                     label: {
-                        LandmarkRow()
+                        LandmarkRow(landmark: landmark1)
                     }
                 )
                 NavigationLink(
-                    destination: ContentView(),
+                    destination: LandmarkDetail(landmark: landmark2),
                     label: {
-                        LandmarkRow()
+                        LandmarkRow(landmark: landmark2)
                     }
                 )
             }

--- a/Landmark/Views/LandmarkRow.swift
+++ b/Landmark/Views/LandmarkRow.swift
@@ -8,12 +8,14 @@
 import SwiftUI
 
 struct LandmarkRow: View {
+    var landmark: Landmark
+    
     var body: some View {
         HStack {
-            Image("turtlerock")
+            Image(landmark.imageName)
                 .resizable()
                 .frame(width: 50, height:50)
-            Text("Turtle Rock")
+            Text(landmark.name)
 
             Spacer()
         }
@@ -22,7 +24,24 @@ struct LandmarkRow: View {
 
 struct LandmarkRow_Previews: PreviewProvider {
     static var previews: some View {
-        LandmarkRow()
-            .previewLayout(.fixed(width: 300, height: 70))
+        LandmarkRow(
+            landmark: Landmark(
+                id: 1001,
+                name: "Turtle Rock",
+                category: "Rivers",
+                city: "Twentynine Palms",
+                state: "California",
+                isFeatured: true,
+                isFavorite: true,
+                park: "Joshua Tree National Park",
+                coordinates: Coordinate(
+                    longitude: -116.166868,
+                    latitude: 34.011286
+                ),
+                description: "Suscipit inceptos ...",
+                imageName: "turtlerock"
+            )
+        )
+        .previewLayout(.fixed(width: 300, height: 70))
     }
 }

--- a/Landmark/Views/MapView.swift
+++ b/Landmark/Views/MapView.swift
@@ -9,18 +9,28 @@ import SwiftUI
 import MapKit
 
 struct MapView: View {
-    @State private var region = MKCoordinateRegion(
-        center: CLLocationCoordinate2D(latitude: 35.6068168, longitude: 139.6847725),
-        span: MKCoordinateSpan(latitudeDelta: 0.01, longitudeDelta: 0.01)
-    )
+    let coordinates: Coordinate
     
+    @State private var region = MKCoordinateRegion()
+
     var body: some View {
         Map(coordinateRegion: $region)
+            .onAppear {
+                region = MKCoordinateRegion(
+                    center: CLLocationCoordinate2D(latitude: coordinates.latitude, longitude: coordinates.longitude),
+                    span: MKCoordinateSpan(latitudeDelta: 0.01, longitudeDelta: 0.01)
+                )
+            }
     }
 }
 
 struct MapView_Previews: PreviewProvider {
     static var previews: some View {
-        MapView()
+        MapView(
+            coordinates: Coordinate(
+                longitude: 139.6847725,
+                latitude: 35.6068168
+            )
+        )
     }
 }


### PR DESCRIPTION
## 概要
・LandmarkRowに変数を渡して、表示内容を変更できるようにした
・CircleImage,MapViewが変数を受け取れるようにして、LandmarkDetailに渡した変数の内容を表示できるようにした

## スクリーンショット
|講義リスト|詳細|
|---|---|
|![Simulator Screen Shot - iPhone 12 - 2021-06-20 at 23 46 02](https://user-images.githubusercontent.com/64680945/122678463-05070800-d222-11eb-9af4-a8b3af0911ab.png)|![ScreenShot 2021-06-20 23 47 15](https://user-images.githubusercontent.com/64680945/122678508-2ff15c00-d222-11eb-8a57-ee3d225c787d.png)|
